### PR TITLE
Bhs/releases content

### DIFF
--- a/src/components/ReleasesBinary.tsx
+++ b/src/components/ReleasesBinary.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+const ReleasesBinary = ({binary}) => {
+    return (
+        <div>
+            {binary.installer_link ?
+                <div>
+                    <a href='' className='latest-download-button a-button'>
+                        <div className='large-dl-text'>Install {binary.type}
+                            <div className='small-dl-text'>Installer</div>
+                        </div>
+                    </a>
+                    <a href={binary.link} className='latest-download-button latest-download-button-grey a-button'>
+                        <div className='large-dl-text'>Download {binary.type}
+                            <div className='small-dl-text'>{`${binary.extension} - ${binary.size} MB`}</div>
+                        </div>
+                    </a>
+                </div>
+                :
+                <a href={binary.link} className='latest-download-button a-button'>
+                    <div className='large-dl-text'>Download {binary.type}
+                        <div className='small-dl-text'>{`${binary.extension} - ${binary.size} MB`}</div>
+                    </div>
+                </a>
+            }
+            <div className='latest-details'>
+                <p><a href={binary.checksum_link} className='dark-link' target='_blank'>Checksum</a></p>
+            </div>
+        </div>
+    )
+}
+
+export default ReleasesBinary

--- a/src/components/ReleasesPlatformItem.tsx
+++ b/src/components/ReleasesPlatformItem.tsx
@@ -1,0 +1,43 @@
+import React, {FunctionComponent} from "react"
+import {Platform} from "../types"
+import ReleasesBinary from "./ReleasesBinary";
+
+export interface ReleasesPlatformItemProps {
+    platform?: Platform
+}
+
+const ReleasesPlatformItem: FunctionComponent<ReleasesPlatformItemProps> = ({platform}) => {
+    return (
+        <div>
+            <div className="latest-asset latest-grid-border" id={`latest-selector-${platform.name}`}>
+                <img alt={`/${platform.official_name} logo`} src={`/${platform.logo}`}/>
+                <h2 className="officialName">{platform.official_name}</h2>
+                <p className="releaseName">{platform.release_name}</p>
+            </div>
+            <div id="latest-info">
+                <div id={`latest-info-${platform.name}`} className='latest-info-container latest-grid-border'>
+                    <div className='platform-section'>
+                        <img alt='{platform.official_name} logo' src={platform.logo}/>
+                        <h2 className="officialName">{platform.official_name}</h2>
+                        <p className="releaseName">
+                            <a href={platform.release_link} className='dark-link'
+                               target='_blank'>{platform.release_name}</a></p>
+                        <p className="releaseDateTime">{platform.release_datetime}}</p>
+                        <p className="latest-selector-back-button">
+                            <i className="fa fa-arrow-left" aria-hidden="true"/> Back to platforms
+                        </p>
+                    </div>
+                    <div className='content-section'>
+                        <div className='latest-block'>
+                            {platform.binaries.map(binary => <ReleasesBinary binary={binary}/>)}
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+
+    )
+}
+
+export default ReleasesPlatformItem;

--- a/src/components/ReleasesPlatforms.tsx
+++ b/src/components/ReleasesPlatforms.tsx
@@ -1,0 +1,29 @@
+import React, {FunctionComponent} from "react"
+import {Platform} from "../types";
+import ReleasesPlatformItem from "./ReleasesPlatformItem";
+
+export interface ReleasesPlatformsProps {
+    platforms?: Platform[]
+}
+
+const ReleasesPlatforms: FunctionComponent<ReleasesPlatformsProps> = ({platforms}) => {
+    return (
+        <div>
+            <h3><a href="">All Release Notes</a></h3>
+            <h2 id="latest-select-text" style={{marginBottom: '0.5rem'}}>Select a platform</h2>
+
+            <div id="latest-selector">
+                <a id="docker_link" href="" target="_blank">
+                    <div className="docker-asset latest-grid-border" id='latest-selector-Docker'>
+                        <img alt='Docker logo' src='./dist/assets/docker.png'/>
+                        <h2 className="officialName">Docker</h2>
+                        <p className="releaseName">Official Image</p>
+                    </div>
+                </a>
+                { platforms.map( platform => <ReleasesPlatformItem platform={platform}/>)}
+            </div>
+        </div>
+    )
+}
+
+export default ReleasesPlatforms;

--- a/src/pages/releases.tsx
+++ b/src/pages/releases.tsx
@@ -1,77 +1,12 @@
 import React, {FunctionComponent} from "react"
-import {ChoiceGroup} from 'office-ui-fabric-react/lib/ChoiceGroup';
+import {ChoiceGroup} from "office-ui-fabric-react/lib/ChoiceGroup"
 
 import Layout from "../components/Layout"
+import ReleasesPlatforms from "../components/ReleasesPlatforms"
+
 import "../scss/styles-4-releases.scss"
 
-export interface ReleasesProps {
-}
-
-const ReleaseTile = ({platform}) => {
-    return (
-        <div className="latest-asset latest-grid-border" id={`latest-selector-${platform.name}`}>
-            <img alt={`/${platform.official_name} logo`} src={`/${platform.logo}`}/>
-            <h2 className="officialName">{platform.official_name}</h2>
-            <p className="releaseName">{platform.release_name}</p>
-        </div>
-    )
-}
-
-const BinaryDownload = ({binary}) => {
-    return (
-        <div>
-            {binary.installer_link ?
-                <div>
-                    <a href='' className='latest-download-button a-button'>
-                        <div className='large-dl-text'>Install {binary.type}
-                            <div className='small-dl-text'>Installer</div>
-                        </div>
-                    </a>
-                    <a href={binary.link} className='latest-download-button latest-download-button-grey a-button'>
-                        <div className='large-dl-text'>Download {binary.type}
-                            <div className='small-dl-text'>{`${binary.extension} - ${binary.size} MB`}</div>
-                        </div>
-                    </a>
-                </div>
-                :
-                <a href={binary.link} className='latest-download-button a-button'>
-                    <div className='large-dl-text'>Download {binary.type}
-                        <div className='small-dl-text'>{`${binary.extension} - ${binary.size} MB`}</div>
-                    </div>
-                </a>
-            }
-            <div className='latest-details'>
-                <p><a href={binary.checksum_link} className='dark-link' target='_blank'>Checksum</a></p>
-            </div>
-        </div>
-    )
-}
-
-const ReleaseDetail = ({platform}) => {
-    return (
-        <div id="latest-info">
-            <div id={`latest-info-${platform.name}`} className='latest-info-container latest-grid-border'>
-                <div className='platform-section'>
-                    <img alt='{platform.official_name} logo' src={platform.logo}/>
-                    <h2 className="officialName">{platform.official_name}</h2>
-                    <p className="releaseName">
-                        <a href={platform.release_link} className='dark-link'
-                           target='_blank'>{platform.release_name}</a></p>
-                    <p className="releaseDateTime">{platform.release_datetime}}</p>
-                    <p className="latest-selector-back-button">
-                        <i className="fa fa-arrow-left" aria-hidden="true"/> Back to platforms
-                    </p>
-                </div>
-                <div className='content-section'>
-                    <div className='latest-block'>
-                        {platform.binaries.map(binary => <BinaryDownload binary={binary}/>)}
-                    </div>
-                </div>
-
-            </div>
-        </div>
-    )
-}
+export interface ReleasesProps {}
 
 export const Releases: FunctionComponent<ReleasesProps> = props => {
 
@@ -89,7 +24,6 @@ export const Releases: FunctionComponent<ReleasesProps> = props => {
                 installer_link: '',
                 size: '99',
                 extension: '.tar.gz'
-
             }
         ]
     }]
@@ -104,13 +38,13 @@ export const Releases: FunctionComponent<ReleasesProps> = props => {
                         <a href="./archive.html" className="blue-button a-button">
                             <div>
                                 <span>Build archive</span>
-                                <i className="fa fa-arrow-circle-o-right" aria-hidden="true"></i>
+                                <i className="fa fa-arrow-circle-o-right" aria-hidden="true" />
                             </div>
                         </a>
                         <a href="./nightly.html" id="nightly-button" className="grey-button a-button">
                             <div>
                                 <span>Nightly builds</span>
-                                <i className="fa fa-arrow-circle-o-right" aria-hidden="true"></i>
+                                <i className="fa fa-arrow-circle-o-right" aria-hidden="true" />
                             </div>
                         </a>
 
@@ -155,21 +89,7 @@ export const Releases: FunctionComponent<ReleasesProps> = props => {
                     </div>
 
                     <div id="latest-container">
-                        <h3><a href="">All Release Notes</a></h3>
-                        <h2 id="latest-select-text" style={{marginBottom: '0.5rem'}}>Select a platform</h2>
-
-                        <div id="latest-selector">
-                            <a id="docker_link" href="" target="_blank">
-                                <div className="docker-asset latest-grid-border" id='latest-selector-Docker'>
-                                    <img alt='Docker logo' src='./dist/assets/docker.png'/>
-                                    <h2 className="officialName">Docker</h2>
-                                    <p className="releaseName">Official Image</p>
-                                </div>
-                            </a>
-                            <ReleaseTile platform={platforms[0]}/>
-                            <ReleaseDetail platform={platforms[0]}/>
-                        </div>
-
+                        <ReleasesPlatforms platforms={platforms} />
                     </div>
                 </div>
             </main>

--- a/src/pages/releases.tsx
+++ b/src/pages/releases.tsx
@@ -1,0 +1,49 @@
+import React, {FunctionComponent} from "react"
+
+import Layout from "../components/Layout"
+import "../scss/styles-4-releases.scss"
+
+export interface ReleasesProps {}
+
+export const Releases: FunctionComponent<ReleasesProps> = props => {
+    return (
+        <Layout>
+            <main className="grey-bg">
+                <div id="latest-page" style={{ marginBottom: '2rem' }}>
+                    <h1 className="large-title">Latest release</h1>
+
+                    <div>
+                        <a href="./archive.html" className="blue-button a-button">
+                            <div>
+                                <span>Build archive</span>
+                                <i className="fa fa-arrow-circle-o-right" aria-hidden="true"></i>
+                            </div>
+                        </a>
+                        <a href="./nightly.html" id="nightly-button" className="grey-button a-button">
+                            <div>
+                                <span>Nightly builds</span>
+                                <i className="fa fa-arrow-circle-o-right" aria-hidden="true"></i>
+                            </div>
+                        </a>
+
+                        <div className="btn-container">
+                            <form id="jdk-selector" className="btn-form">
+                                <h3>1. Choose a Version</h3>
+                            </form>
+                            <form id="jvm-selector" className="btn-form">
+                                <h3>2. Choose a JVM</h3>
+                            </form>
+                        </div>
+
+                        <div id="loading">
+                            <img src="dist/assets/loading_dots.gif" width="40" height="40" alt="Content is loading." />
+                        </div>
+                        <div id="error-container"></div>
+                    </div>
+                </div>
+            </main>
+        </Layout>
+    )
+}
+
+export default Releases

--- a/src/pages/releases.tsx
+++ b/src/pages/releases.tsx
@@ -1,15 +1,103 @@
 import React, {FunctionComponent} from "react"
+import {ChoiceGroup} from 'office-ui-fabric-react/lib/ChoiceGroup';
 
 import Layout from "../components/Layout"
 import "../scss/styles-4-releases.scss"
 
-export interface ReleasesProps {}
+export interface ReleasesProps {
+}
+
+const ReleaseTile = ({platform}) => {
+    return (
+        <div className="latest-asset latest-grid-border" id={`latest-selector-${platform.name}`}>
+            <img alt={`/${platform.official_name} logo`} src={`/${platform.logo}`}/>
+            <h2 className="officialName">{platform.official_name}</h2>
+            <p className="releaseName">{platform.release_name}</p>
+        </div>
+    )
+}
+
+const BinaryDownload = ({binary}) => {
+    return (
+        <div>
+            {binary.installer_link ?
+                <div>
+                    <a href='' className='latest-download-button a-button'>
+                        <div className='large-dl-text'>Install {binary.type}
+                            <div className='small-dl-text'>Installer</div>
+                        </div>
+                    </a>
+                    <a href={binary.link} className='latest-download-button latest-download-button-grey a-button'>
+                        <div className='large-dl-text'>Download {binary.type}
+                            <div className='small-dl-text'>{`${binary.extension} - ${binary.size} MB`}</div>
+                        </div>
+                    </a>
+                </div>
+                :
+                <a href={binary.link} className='latest-download-button a-button'>
+                    <div className='large-dl-text'>Download {binary.type}
+                        <div className='small-dl-text'>{`${binary.extension} - ${binary.size} MB`}</div>
+                    </div>
+                </a>
+            }
+            <div className='latest-details'>
+                <p><a href={binary.checksum_link} className='dark-link' target='_blank'>Checksum</a></p>
+            </div>
+        </div>
+    )
+}
+
+const ReleaseDetail = ({platform}) => {
+    return (
+        <div id="latest-info">
+            <div id={`latest-info-${platform.name}`} className='latest-info-container latest-grid-border'>
+                <div className='platform-section'>
+                    <img alt='{platform.official_name} logo' src={platform.logo}/>
+                    <h2 className="officialName">{platform.official_name}</h2>
+                    <p className="releaseName">
+                        <a href={platform.release_link} className='dark-link'
+                           target='_blank'>{platform.release_name}</a></p>
+                    <p className="releaseDateTime">{platform.release_datetime}}</p>
+                    <p className="latest-selector-back-button">
+                        <i className="fa fa-arrow-left" aria-hidden="true"/> Back to platforms
+                    </p>
+                </div>
+                <div className='content-section'>
+                    <div className='latest-block'>
+                        {platform.binaries.map(binary => <BinaryDownload binary={binary}/>)}
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    )
+}
 
 export const Releases: FunctionComponent<ReleasesProps> = props => {
+
+    const platforms = [{
+        name: 'X64_LINUX',
+        logo: '',
+        official_name: 'Linux x64',
+        release_name: 'jdk8u212-b03',
+        release_link: '/',
+        release_datetime: '2019-04-18 03:49:04',
+        binaries: [
+            {
+                type: 'JDK',
+                link: 'https://www.github.com',
+                installer_link: '',
+                size: '99',
+                extension: '.tar.gz'
+
+            }
+        ]
+    }]
+
     return (
         <Layout>
             <main className="grey-bg">
-                <div id="latest-page" style={{ marginBottom: '2rem' }}>
+                <div id="latest-page" style={{marginBottom: '2rem'}}>
                     <h1 className="large-title">Latest release</h1>
 
                     <div>
@@ -29,16 +117,59 @@ export const Releases: FunctionComponent<ReleasesProps> = props => {
                         <div className="btn-container">
                             <form id="jdk-selector" className="btn-form">
                                 <h3>1. Choose a Version</h3>
+                                <ChoiceGroup
+                                    defaultSelectedKey="A"
+                                    options={[
+                                        {
+                                            key: 'A',
+                                            text: 'OpenJDK 8 (LDS)'
+                                        },
+                                        {
+                                            key: 'B',
+                                            text: 'OpenJDK 9'
+                                        },
+                                        {
+                                            key: 'C',
+                                            text: 'OpenJDK 10'
+                                        }
+                                    ]}
+                                />
                             </form>
                             <form id="jvm-selector" className="btn-form">
                                 <h3>2. Choose a JVM</h3>
+                                <ChoiceGroup
+                                    defaultSelectedKey="A"
+                                    options={[
+                                        {
+                                            key: 'A',
+                                            text: 'HotSpot'
+                                        },
+                                        {
+                                            key: 'B',
+                                            text: 'OpenJ9'
+                                        }
+                                    ]}
+                                />
                             </form>
                         </div>
+                    </div>
 
-                        <div id="loading">
-                            <img src="dist/assets/loading_dots.gif" width="40" height="40" alt="Content is loading." />
+                    <div id="latest-container">
+                        <h3><a href="">All Release Notes</a></h3>
+                        <h2 id="latest-select-text" style={{marginBottom: '0.5rem'}}>Select a platform</h2>
+
+                        <div id="latest-selector">
+                            <a id="docker_link" href="" target="_blank">
+                                <div className="docker-asset latest-grid-border" id='latest-selector-Docker'>
+                                    <img alt='Docker logo' src='./dist/assets/docker.png'/>
+                                    <h2 className="officialName">Docker</h2>
+                                    <p className="releaseName">Official Image</p>
+                                </div>
+                            </a>
+                            <ReleaseTile platform={platforms[0]}/>
+                            <ReleaseDetail platform={platforms[0]}/>
                         </div>
-                        <div id="error-container"></div>
+
                     </div>
                 </div>
             </main>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -7,3 +7,14 @@ declare module "*.svg" {
   const content: any
   export default content
 }
+
+export interface Platform {
+  name?: string,
+  logo?: string,
+  official_name?: string
+  release_name?: string
+  release_link?: string
+  release_datetime?: string
+  binaries: object[]
+}
+


### PR DESCRIPTION
Adding a couple of components here for the releases content page -- moving slow as I'm getting to know the stack and the website so I didn't make it as far as I want. I'm pretending there is data eventually to reduce the workload later on. 

I am not going to merge this so that you can weigh in if this is the wrong direction/approach. I'm leaving the markup pretty much as is from handlebars -- but I think it can definitely be refactored as we improve the structures here.